### PR TITLE
DDrag Version, Resources, New Champ

### DIFF
--- a/lolstaticdata/champions/__main__.py
+++ b/lolstaticdata/champions/__main__.py
@@ -27,8 +27,6 @@ def main():
     if not os.path.exists(os.path.join(directory, "champions")):
         os.mkdir(os.path.join(directory, "champions"))
 
-    latest_version = utils.get_latest_patch_version()
-
     # Load some information for pulling champion ability icons
     latest_version = utils.get_latest_patch_version()
     ddragon_champions = utils.download_json(

--- a/lolstaticdata/champions/__main__.py
+++ b/lolstaticdata/champions/__main__.py
@@ -30,6 +30,7 @@ def main():
     latest_version = utils.get_latest_patch_version()
 
     # Load some information for pulling champion ability icons
+    latest_version = utils.get_latest_patch_version()
     ddragon_champions = utils.download_json(
         f"http://ddragon.leagueoflegends.com/cdn/{latest_version}/data/en_US/championFull.json"
     )["data"]
@@ -52,7 +53,7 @@ def main():
 
         # Set the champion icon
         champion.icon = (
-            f"http://ddragon.leagueoflegends.com/cdn/10.8.1/img/champion/{ddragon_champion['image']['full']}"
+            f"http://ddragon.leagueoflegends.com/cdn/{latest_version}/img/champion/{ddragon_champion['image']['full']}"
         )
 
         # Set the lore

--- a/lolstaticdata/champions/modelchampion.py
+++ b/lolstaticdata/champions/modelchampion.py
@@ -48,6 +48,8 @@ class Resource(OrderedEnum):
     SHIELD = "SHIELD"
     OTHER = "OTHER"
     NONE = "NONE"
+    SOUL_UNBOUND = "SOUL_UNBOUND"
+    BLOOD_WELL = "BLOOD_WELL"
 
 
 class AttackType(OrderedEnum):

--- a/lolstaticdata/champions/pull_champions_wiki.py
+++ b/lolstaticdata/champions/pull_champions_wiki.py
@@ -3,6 +3,7 @@ import re
 from bs4 import BeautifulSoup
 from collections import Counter
 from slpp import slpp as lua
+from datetime import datetime
 
 from ..common.modelcommon import (
     DamageType,
@@ -149,7 +150,7 @@ class LolWikiDataHandler:
                 continue
                 #name = "Kled"
                 #d["id"] = 240
-            if name == "Samira": #Samira is on Wiki but not released yet
+            if d["id"] == 9999 or datetime.strptime(d["date"], "%Y-%m-%d") > datetime.today(): #Champion not released yet
                 continue
             champion = self._render_champion_data(name, d)
             yield champion

--- a/lolstaticdata/common/utils.py
+++ b/lolstaticdata/common/utils.py
@@ -146,7 +146,7 @@ def download_soup(url: str, use_cache: bool = True):
         page = requests.get(url)
         html = page.content.decode(page.encoding)
         if use_cache:
-            with open(fn, "w") as f:
+            with open(fn, "w", encoding="utf-8") as f:
                 f.write(html)
     soup = BeautifulSoup(html, "lxml")
     html = str(soup)


### PR DESCRIPTION
Uses newest DDragon Version instead of being hardcoded, adds SOUL_UNBOUND and BLOOD_WELL, uses ID 9999 (filler ID on wiki) or release date to check on new champion release to stop failure from DDragon, use UTF-8 to open cache to stop crashing