### PR TITLE
[Feature Request] Add factions to champion data

### DIFF
--- a/lolstaticdata/champions/__main__.py
+++ b/lolstaticdata/champions/__main__.py
@@ -32,6 +32,20 @@ def main():
     ddragon_champions = utils.download_json(
         f"http://ddragon.leagueoflegends.com/cdn/{latest_version}/data/en_US/championFull.json"
     )["data"]
+
+    # load a list of champions from universe.leagueoflegends.com => added request faile detection because of unreliable source
+    factions = {}
+    try:
+        universe_stats = utils.download_json(
+            "https://universe-meeps.leagueoflegends.com/v1/en_us/champion-browse/index.json",
+            False
+        )["champions"]
+
+        for champion in universe_stats:
+            factions[champion["slug"]] = champion["associated-faction-slug"]
+    except Exception:
+        print("ERROR: Unable to load/parse universe file, location may have changed")
+
     ability_key_to_identifier = {
         "P": "passive",
         "Q": "q",
@@ -56,6 +70,9 @@ def main():
 
         # Set the lore
         champion.lore = ddragon_champion["lore"]
+
+        # set the faction
+        champion.faction = factions[champion.key.lower()] if champion.key.lower() in factions else ""
 
         # Set the champion ability icons
         for ability_key, abilities in champion.abilities.items():

--- a/lolstaticdata/champions/__main__.py
+++ b/lolstaticdata/champions/__main__.py
@@ -33,7 +33,7 @@ def main():
         f"http://ddragon.leagueoflegends.com/cdn/{latest_version}/data/en_US/championFull.json"
     )["data"]
 
-    # load a list of champions from universe.leagueoflegends.com => added request faile detection because of unreliable source
+    # Load a list of champions from universe.leagueoflegends.com => added request fail detection because of unreliable source
     factions = {}
     try:
         universe_stats = utils.download_json(
@@ -71,8 +71,12 @@ def main():
         # Set the lore
         champion.lore = ddragon_champion["lore"]
 
-        # set the faction
+        # Set the faction
         champion.faction = factions[champion.key.lower()] if champion.key.lower() in factions else ""
+
+        # Fix faction bug for e.g. renata
+        if champion.faction == "" and champion.name.lower().replace(" ","") in factions:
+            champion.faction = factions[champion.name.lower().replace(" ","")]
 
         # Set the champion ability icons
         for ability_key, abilities in champion.abilities.items():

--- a/lolstaticdata/champions/modelchampion.py
+++ b/lolstaticdata/champions/modelchampion.py
@@ -279,6 +279,7 @@ class Champion(object):
     patch_last_changed: str
     price: Price
     lore: str
+    faction: str
     skins: List[Skin]
 
     def __json__(self, *args, **kwargs):

--- a/lolstaticdata/champions/pull_champions_wiki.py
+++ b/lolstaticdata/champions/pull_champions_wiki.py
@@ -356,6 +356,7 @@ class LolWikiDataHandler:
             patch_last_changed=data["changes"][1:],  # remove the leading "V"
             price=Price(rp=data["rp"], blue_essence=data["be"], sale_rp=sale_price),
             lore="",
+            faction="",
             skins=self._get_champ_skin(name, sale),
         )
         # "nickname": "nickname",


### PR DESCRIPTION
This PR adds factions to the champion data. 
Factions are nowadays pretty important, as you need them for e.g. challenges and there is non official JSON-source for factions *yet*.
To provide factions, the script now fetches a static json file from universe.leagueoflegends.com and scan it for the factions on a per-champion-base. 
If the faction can't be matched with a champion, it will return an empty string "". 
There is an error with Renata Glasc, her key is just "renata" but her slug from the universe file is "renataglasc". This issue is fixed by removing spaces from the champion name, set the name to lowercase and compare it then again 
> "Renata Glasc"=> "RenataGlasc"=> "renataglasc"

Also the script prints an error if the universe file can't be found. I checked the file for a few months and it didn't changed url, but as this is more like an "unreliable" source, I added an issue detection and a warning. 

I will also attach the generated champion.json (converted to txt as .json is not allowed) file to this PR. [champions.txt](https://github.com/meraki-analytics/lolstaticdata/files/9490977/champions.txt)

Finally, I also checked the diff of the files generated after the changes with the files generated before the changes, and there was no change in data except for the faction.
