### PR TITLE
Add support for Passive Cooldowns

### DIFF
--- a/lolstaticdata/items/modelitem.py
+++ b/lolstaticdata/items/modelitem.py
@@ -115,8 +115,8 @@ class Passive(object):
     name: str
     effects: str
     range: int
+    cooldown: str
     stats: Stats
-    cooldown: float
 
 
 @dataclasses_json.dataclass_json(letter_case=dataclasses_json.LetterCase.CAMEL)

--- a/lolstaticdata/items/modelitem.py
+++ b/lolstaticdata/items/modelitem.py
@@ -116,6 +116,7 @@ class Passive(object):
     effects: str
     range: int
     stats: Stats
+    cooldown: float
 
 
 @dataclasses_json.dataclass_json(letter_case=dataclasses_json.LetterCase.CAMEL)

--- a/lolstaticdata/items/pull_items_wiki.py
+++ b/lolstaticdata/items/pull_items_wiki.py
@@ -57,6 +57,7 @@ class WikiItem:
                 passive_name,
                 passive_effects,
                 item_range,
+				cd,
             ) = cls._parse_passive_info(passive)
             stats = cls._parse_passive_descriptions(passive_effects)
             effect = Passive(
@@ -66,6 +67,7 @@ class WikiItem:
                 range=item_range,
                 stats=stats,
                 mythic=mythic,
+				cooldown=cd,
             )
             return effect
 
@@ -86,6 +88,7 @@ class WikiItem:
                 name="Mythic",
                 effects=None,
                 range=0,
+                cooldown=0,
                 stats=stats,
                 mythic=True,
             )
@@ -109,6 +112,7 @@ class WikiItem:
                 passive_name,
                 passive_effects,
                 item_range,
+                cd,
             ) = cls._parse_passive_info(passive)
             if get_cooldown.search(passive_effects):
                 cooldown = get_cooldown.search(passive_effects).group(0).split(" ", 1)
@@ -127,7 +131,7 @@ class WikiItem:
         return effects
 
     @classmethod
-    def _parse_passive_info(cls, passive: dict) -> Tuple[bool, bool, Optional[str], str, Optional[int]]:
+    def _parse_passive_info(cls, passive: dict) -> Tuple[bool, bool, Optional[str], str, Optional[int], Optional[str]]:
         if "unique" in passive:
             unique = True
             mythic = False
@@ -138,6 +142,10 @@ class WikiItem:
             name = passive["name"]
         else:
             name = None
+        if "cd" in passive:
+            cd = passive["cd"]
+        else:
+            cd = None
         # elif passive.startswith("Mythic"):
         #     mythic = True
         #     unique = True
@@ -152,7 +160,7 @@ class WikiItem:
             item_range = cls._parse_int(passive["range"])
         else:
             item_range = None
-        return unique, mythic, name, passive["description"], item_range
+        return unique, mythic, name, passive["description"], item_range, cd
 
     @classmethod
     def _parse_passive_descriptions(cls, passive: str) -> Stats:


### PR DESCRIPTION
Currently the data does not give data on the cooldowns of passives on items (for example, the 60 second cooldown on Sterak's Lifeline Passive). This adds a string field displaying the cooldown of the passive.

No other elements should be changed.

String is required (instead of float like actives) because of some cooldowns having caveats (take Sheen for example). In this case, any wikitext is preserved as normal.