### PR TITLE
Fix Active Item Cooldowns and Range

### DIFF
--- a/lolstaticdata/items/modelitem.py
+++ b/lolstaticdata/items/modelitem.py
@@ -125,8 +125,8 @@ class Active(object):
     unique: bool
     name: str
     effects: str
-    range: int
-    cooldown: float
+    range: str
+    cooldown: str
 
 
 @dataclasses_json.dataclass_json(letter_case=dataclasses_json.LetterCase.CAMEL)

--- a/lolstaticdata/items/pull_items_wiki.py
+++ b/lolstaticdata/items/pull_items_wiki.py
@@ -149,9 +149,9 @@ class WikiItem:
         passive = passive
 
         if "radius" in passive:
-            item_range = cls._parse_int(passive["radius"])
+            item_range = passive["radius"]
         elif "range" in passive:
-            item_range = cls._parse_int(passive["range"])
+            item_range = passive["range"]
         else:
             item_range = None
         return unique, mythic, name, passive["description"], item_range, cd

--- a/lolstaticdata/items/pull_items_wiki.py
+++ b/lolstaticdata/items/pull_items_wiki.py
@@ -97,7 +97,6 @@ class WikiItem:
 
     @classmethod
     def _parse_actives(cls, item_data: dict) -> List[Active]:
-        get_cooldown = re.compile(r"(\d+ second cooldown)|(\d+ seconds cooldown)")
         effects = []
         passive = None
         if "effects" in item_data:
@@ -108,22 +107,17 @@ class WikiItem:
         if passive:
             (
                 unique,
-                mythic,
+				mythic,
                 passive_name,
                 passive_effects,
                 item_range,
                 cd,
             ) = cls._parse_passive_info(passive)
-            if get_cooldown.search(passive_effects):
-                cooldown = get_cooldown.search(passive_effects).group(0).split(" ", 1)
-                cooldown = cls._parse_float(cooldown[0])
-            else:
-                cooldown = None
             effect = Active(
                 unique=unique,
                 name=passive_name,
                 effects=passive_effects,
-                cooldown=cooldown,
+                cooldown=cd,
                 range=item_range,
             )  # This is hacky...
 
@@ -131,7 +125,7 @@ class WikiItem:
         return effects
 
     @classmethod
-    def _parse_passive_info(cls, passive: dict) -> Tuple[bool, bool, Optional[str], str, Optional[int], Optional[str]]:
+    def _parse_passive_info(cls, passive: dict) -> Tuple[bool, bool, Optional[str], str, Optional[str], Optional[str]]:
         if "unique" in passive:
             unique = True
             mythic = False


### PR DESCRIPTION
The old regex method of sourcing cooldowns from the wiki is no longer necessary, and has been replaced with a simple working version that grabs the cooldown as a string (to prevent issues of non-float values being replaces with null or 0).

Global range item actives show a range of 0, fixed by making range a string value, allowing the data to be stored.