### PR TITLE
remove unneeded error printed to console

### DIFF
--- a/lolstaticdata/items/pull_items_wiki.py
+++ b/lolstaticdata/items/pull_items_wiki.py
@@ -615,7 +615,6 @@ class WikiItem:
                     try:
                         item_data[x] = wiki_data[item_data[x].replace("=>", "")][x]
                     except KeyError as e:
-                        print(item_data[x],"ERRRRROOOORRRRR",e)
                         clear_keys.append(x)
             if x in "effects":
                 for l in item_data[x]:


### PR DESCRIPTION
This "ERRRRROOOORRRRR" prints to the console every time an Ornn item has a property that doesn't exist on the mythic item it was built from. The property is then removed from the item within the except clause, so unless I'm mistaken, printing the error serves no purpose.