### PR TITLE
fix lethality passive parsing

### DIFF
--- a/lolstaticdata/items/pull_items_wiki.py
+++ b/lolstaticdata/items/pull_items_wiki.py
@@ -167,7 +167,7 @@ class WikiItem:
         # Regex stuff
         cdr = re.compile(r"\d.* cooldown reduction")
         crit = re.compile(r"\d.* critical strike chance")
-        lethality = re.compile(r"(\d.*) (?:lethality|Lethality)", re.IGNORECASE)
+        lethality = re.compile(r"(?:lethality|Lethality)\|(\d*)", re.IGNORECASE)
         movespeed = re.compile(r"(\d+)(?: '*bonus'* |% | |% '*bonus'* )movement speed", re.IGNORECASE) 
         armorpen = re.compile(r"(\d+)% armor penetration")
         magicpen = re.compile(r"(\d+).*? magic penetration")


### PR DESCRIPTION
New regex matches this format from the wiki. Currently, Serrated Dirk's "Gouge" is the only passive (besides mythics) that gives lethality
```
["pass"] = {   
                ["name"]        = "Gouge",
                ["unique"]      = true,
                ["description"] = "Gain {{Lethality|10}}.",
            },
```