### PR TITLE
Added cdragon description to items

### DIFF
--- a/lolstaticdata/items/__main__.py
+++ b/lolstaticdata/items/__main__.py
@@ -35,6 +35,7 @@ def main():
             item.builds_from = cdrag_item.builds_from
             item.builds_into = cdrag_item.builds_into
             item.simple_description = cdrag_item.simple_description
+            item.description = cdrag_item.description
             item.required_ally = cdrag_item.required_ally
             item.required_champion = cdrag_item.required_champion
             item.shop.purchasable = cdrag_item.shop.purchasable

--- a/lolstaticdata/items/modelitem.py
+++ b/lolstaticdata/items/modelitem.py
@@ -146,6 +146,7 @@ class Item(object):
     required_champion: str
     required_ally: str
     icon: str
+    description: str
     simple_description: str
     nicknames: List[str]
     passives: List[Passive]

--- a/lolstaticdata/items/pull_items_dragon.py
+++ b/lolstaticdata/items/pull_items_dragon.py
@@ -54,6 +54,7 @@ class DragonItem:
         cdragid = cdrag["id"]
         icon = cdrag["iconPath"]
         plaintext = cls.get_item_plaintext(cdragid)
+        description = cdrag["description"]
         shop = Shop(purchasable=purchasable, prices=[], tags=[])
         item = Item(
             builds_from=builds_from,
@@ -67,6 +68,7 @@ class DragonItem:
             required_ally=ally,
             required_champion=champ,
             simple_description=plaintext,
+            description=description,
             nicknames=[],
             passives=[],
             active=[],

--- a/lolstaticdata/items/pull_items_wiki.py
+++ b/lolstaticdata/items/pull_items_wiki.py
@@ -726,6 +726,7 @@ class WikiItem:
             active=cls._parse_actives(item_data),
             required_champion="",
             required_ally="",
+            description="",
             simple_description="",
             stats=stats,
 


### PR DESCRIPTION
Adds descriptions like the following to each item:
`"description": "<mainText><stats><attention> 250</attention> Health<br><attention> 35</attention> Armor<br><attention> 250</attention> Mana<br><attention> 20</attention> Ability Haste</stats><br><br> <active>Active -</active> <active>Conduit:</active> Designate an <attention>Accomplice</attention>.<br><li><passive>Convergence:</passive> After you <status>Immobilize</status> an enemy, your <attention>Accomplice's</attention> Attacks and Ability hits apply additional damage to that enemy.<br><br><rules>Champions can only be linked by one Zeke's Convergence at a time.</rules></mainText><br>",`