### PR TITLE
Grab ability range from wiki

### DIFF
--- a/lolstaticdata/champions/pull_champions_wiki.py
+++ b/lolstaticdata/champions/pull_champions_wiki.py
@@ -528,6 +528,7 @@ class LolWikiDataHandler:
                 angle=data.get("angle"),
                 cast_time=data.get("cast time"),
                 effect_radius=data.get("effect radius"),
+                range=data.get("range"),
                 target_range=data.get("target range"),
             )
             if ability.notes is not None and ability.notes.startswith("*"):


### PR DESCRIPTION
Abilities are only tracking target range right now, which directional casted abilities don't have. Added a line to grab ability range from the wiki. Consider making target range the same as cast range for directional casted abilities?