### PR TITLE
fix: Unknown Resource type: CRIMSON_RUSH

### DIFF
--- a/lolstaticdata/champions/modelchampion.py
+++ b/lolstaticdata/champions/modelchampion.py
@@ -50,7 +50,7 @@ class Resource(OrderedEnum):
     NONE = "NONE"
     SOUL_UNBOUND = "SOUL_UNBOUND"
     BLOOD_WELL = "BLOOD_WELL"
-
+    CRIMSON_RUSH = "CRIMSON_RUSH"
 
 class AttackType(OrderedEnum):
     MELEE = "MELEE"


### PR DESCRIPTION
It seems that Vladimir his ResourceType we grab has been changed/renamed from BLOODTHIRST to CRIMSON_RUSH. 
This caused the script to crash with "ValueError: Unknown Resource type: CRIMSON_RUSH" when running `py -m lolstaticdata.champions`

Might be related to this change: https://leagueoflegends.fandom.com/wiki/Module:ChampionData?diff=prev&oldid=3718612