### PR TITLE
fix: Replace fuzzywuzzy with thefuzz

### DIFF
--- a/lolstaticdata/champions/pull_champions_dragons.py
+++ b/lolstaticdata/champions/pull_champions_dragons.py
@@ -1,4 +1,4 @@
-from fuzzywuzzy import fuzz
+from thefuzz import fuzz
 from functools import partial
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ lxml
 natsort
 requests
 slpp
-fuzzywuzzy
+thefuzz
 stringcase


### PR DESCRIPTION
The `fuzzywuzzy` library has been renamed to `thefuzz` (see: https://github.com/seatgeek/fuzzywuzzy?tab=readme-ov-file#this-project-has-been-renamed-and-moved-to-httpsgithubcomseatgeekthefuzz).
There doesn't seem to be anything broken with `fuzzywuzzy` but `thefuzz` actually receives updates.

This commit just updates the requirements and import to use `thefuzz`. 

Didn't find any issue or PR talking about this before, so if there is any reason why lolstaticdata needs to use `fuzzywuzzy` instead just let me know.