### PR TITLE
update 'get_item_plaintext' URL to the latest version

### DIFF
--- a/lolstaticdata/items/pull_items_dragon.py
+++ b/lolstaticdata/items/pull_items_dragon.py
@@ -28,7 +28,7 @@ class DragonItem:
 
     @staticmethod
     def get_item_plaintext(item):
-        url = f"https://raw.communitydragon.org/{DragonItem.version}/game/en_us/data/menu/en_us/main.stringtable.json"
+        url = f"https://raw.communitydragon.org/latest/game/en_us/data/menu/en_us/lol.stringtable.json"
         j = download_json(url, use_cache=True)
         try:
             return j['entries']["game_item_plaintext_" + str(item)]


### PR DESCRIPTION
The get_item_plaintext function previously utilized an outdated version in its URL path, which led to failures when attempting to retrieve item JSON data files. The filename in the latest version is lol.stringtable.json. This update modifies the URL to align with the newest version, ensuring successful data retrieval.