### PR TITLE
fix: avoid crash due to missing Milio skill

### DIFF
--- a/lolstaticdata/champions/pull_champions_wiki.py
+++ b/lolstaticdata/champions/pull_champions_wiki.py
@@ -110,6 +110,7 @@ class LolWikiDataHandler:
         "Annie": ["Command Tibbers"],
         "Jinx": ["Switcheroo! 2"],
         "Lillia": ["Prance"],
+        "Milio": ["Cozy Campfire 2"],
         "Mordekaiser": ["Indestructible 2"],
         "Nidalee": ["Aspect of the Cougar 2"],
         "Pyke": ["Death from Below 2"],


### PR DESCRIPTION
```
Milio
  Fired_Up!
https://wiki.leagueoflegends.com/en-us/Template:Data_Milio/Fired_Up!
  Ultra_Mega_Fire_Kick
https://wiki.leagueoflegends.com/en-us/Template:Data_Milio/Ultra_Mega_Fire_Kick
  Cozy_Campfire
https://wiki.leagueoflegends.com/en-us/Template:Data_Milio/Cozy_Campfire
  Cozy_Campfire_2
https://wiki.leagueoflegends.com/en-us/Template:Data_Milio/Cozy_Campfire_2
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Coding\temp\lolstaticdata\lolstaticdata\champions\__main__.py", line 110, in <module>
    main()
  File "C:\Coding\temp\lolstaticdata\lolstaticdata\champions\__main__.py", line 59, in main
    for champion in handler.get_champions():
                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Coding\temp\lolstaticdata\lolstaticdata\champions\pull_champions_wiki.py", line 182, in get_champions
    champion = self._render_champion_data(name, d)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Coding\temp\lolstaticdata\lolstaticdata\champions\pull_champions_wiki.py", line 328, in _render_champion_data
    self._pull_champion_ability(champion_name=name, ability_name=ability_name)
  File "C:\Coding\temp\lolstaticdata\lolstaticdata\champions\pull_champions_wiki.py", line 385, in _pull_champion_ability
    return HTMLAbilityWrapper(soup)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Coding\temp\lolstaticdata\lolstaticdata\champions\pull_champions_wiki.py", line 68, in __init__
    start = strip_table.index("Parameter") + 3
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: 'Parameter' is not in list

```