### PR TITLE
fix: remove comments to resolve Luna parsing error

### DIFF
--- a/lolstaticdata/champions/pull_champions_wiki.py
+++ b/lolstaticdata/champions/pull_champions_wiki.py
@@ -206,6 +206,11 @@ class LolWikiDataHandler:
                 continue
             else:
                 return False
+    
+    def remove_comments(self, data):
+        comment_pattern = re.compile(r'--(?![^\"]*\"|[^\']*\'|[^\[]*\[).*')
+        data = [comment_pattern.sub("", line) for line in data]
+        return "".join(data)
 
     def get_champions(self) -> Iterator[Champion]:
         # Download the page source
@@ -224,11 +229,7 @@ class LolWikiDataHandler:
                 spans[i] = "{"
         split_stuff = re.compile("({)|(})")
         spans = spans[start:]
-        for i, span in enumerate(spans):
-            if span in ["-- </pre>", "-- [[Category:Lua]]"]:
-                spans[i] = ""
-
-        spans = "".join(spans)
+        spans = self.remove_comments(spans)
         data = lua.decode(spans)
 
         # Return the champData as a list of Champions
@@ -789,22 +790,7 @@ class LolWikiDataHandler:
                 start = i
                 spans[i] = "{"
         spans = spans[start:]
-        test1 = re.compile("\w -- \w|.\w--\w|\w --\w|.\w--\s")
-        for i, span in enumerate(spans):
-            if span in ["-- </pre>", "-- [[Category:Lua]]"]:
-                spans[i] = ""
-
-            if re.search(test1, span):
-                test2 = re.search(test1, span)
-                spans[i] = span.replace(test2.group()[2] + test2.group()[3], " ")
-                span = spans[i]
-
-            comment_start = span.find("--")
-            # text = text.replace("-", " ")
-            if comment_start > -1:
-                spans[i] = span[:comment_start]
-
-        spans = "".join(spans)
+        spans = self.remove_comments(spans)
         skin_data = lua.decode(spans)
         return skin_data
 


### PR DESCRIPTION
Resolving Luna parsing error introduced by https://wiki.leagueoflegends.com/en-us/Module:ChampionData/data?diff=prev&oldid=3887431


```
 File "/home/runner/lolstaticdata/champions/__main__.py", line 123, in <module>
    main()
  File "/home/runner/lolstaticdata/champions/__main__.py", line 67, in main
    for champion in handler.get_champions():
                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/lolstaticdata/champions/pull_champions_wiki.py", line 232, in get_champions
    data = lua.decode(spans)
           ^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/slpp.py", line 50, in decode
    result = self.value()
             ^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/slpp.py", line 143, in value
    return self.object()
           ^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/slpp.py", line 219, in object
    o[k] = self.value()
           ^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/slpp.py", line 143, in value
    return self.object()
           ^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/slpp.py", line 219, in object
    o[k] = self.value()
           ^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/slpp.py", line 143, in value
    return self.object()
           ^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/slpp.py", line 224, in object
    raise ParseError(ERRORS['unexp_end_table'])  # Bad exit here
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
slpp.ParseError: Unexpected end of table while parsing Lua string.
```