### PR TITLE
Add item modes property

### DIFF
--- a/lolstaticdata/items/modelitem.py
+++ b/lolstaticdata/items/modelitem.py
@@ -70,6 +70,14 @@ class ItemRanks(OrderedEnum):
     SPECIAL = "SPECIAL"
 
 
+class ItemModes(OrderedEnum):
+    CLASSIC = "classic"
+    ARAM = "aram"
+    NEXUS_BLITZ = "nexusBlitz"
+    ARENA = "arena"
+    MAYHEM = "mayhem"
+
+
 @dataclasses_json.dataclass_json(letter_case=dataclasses_json.LetterCase.CAMEL)
 @dataclass
 class Stats(object):
@@ -157,6 +165,7 @@ class Item(object):
     stats: Stats
     shop: Shop
     iconOverlay: str
+    modes: List[str]
 
     def __json__(self, *args, **kwargs):
         # Use dataclasses_json to get the dict

--- a/lolstaticdata/items/pull_items_dragon.py
+++ b/lolstaticdata/items/pull_items_dragon.py
@@ -75,6 +75,7 @@ class DragonItem:
             rank="",
             special_recipe=special_recipe,
             iconOverlay=None,
+            modes=[],
         )
         return item
 
@@ -140,5 +141,6 @@ class DragonItem:
             stats=[],
             shop=shop,
             rank="",
+            modes=[],
         )
         return item

--- a/lolstaticdata/items/pull_items_wiki.py
+++ b/lolstaticdata/items/pull_items_wiki.py
@@ -13,6 +13,7 @@ from .modelitem import (
     Active,
     ItemAttributes,
     ItemRanks,
+    ItemModes,
 )
 from ..common.utils import (
     download_soup,
@@ -47,6 +48,30 @@ from ..common.modelcommon import (
 
 
 class WikiItem:
+    WIKI_MODE_MAP = {
+        "classic sr 5v5": ItemModes.CLASSIC,
+        "aram": ItemModes.ARAM,
+        "nb": ItemModes.NEXUS_BLITZ,
+        "ar": ItemModes.ARENA,
+        "mayhem": ItemModes.MAYHEM,
+    }
+
+    @classmethod
+    def _parse_modes(cls, item_data: dict) -> List[str]:
+        modes = []
+        wiki_modes = item_data.get("modes")
+        if not isinstance(wiki_modes, dict):
+            return modes
+        for wiki_key, enabled in wiki_modes.items():
+            if not enabled:
+                continue
+            mode = cls.WIKI_MODE_MAP.get(wiki_key)
+            if mode is None:
+                print(f"WARNING: Unknown item mode '{wiki_key}'")
+                continue
+            modes.append(mode)
+        return modes
+
     @classmethod
     def _parse_passives(cls, item_data: dict) -> List[Passive]:
         effects = []
@@ -767,6 +792,7 @@ class WikiItem:
             rank=rank,
             special_recipe=0,
             iconOverlay=ornn,
+            modes=cls._parse_modes(item_data),
         )
         return item
 


### PR DESCRIPTION
Adds a new property to item data to identify which game modes the item is available in:
```
"modes": [
  "classic",
  "aram",
  "nexusBlitz",
  "arena", 
  "mayhem"
]
```
Resolves #51 
