### PR TITLE
Update __main__.py

### DIFF
--- a/lolstaticdata/champions/__main__.py
+++ b/lolstaticdata/champions/__main__.py
@@ -14,7 +14,7 @@ def get_ability_filenames(url):
     soup = BeautifulSoup(soup, "lxml")
 
     filenames = []
-    for td in soup.findAll("td"):
+    for td in soup.find_all("td"):
         a = td.a
         if a is not None:
             fn = a["href"]


### PR DESCRIPTION
In line 17, findAll() has been deprecated and replaced find_all.

Proof the error in the console says:

"lolstaticdata\lolstaticdata\champions\__main__.py:17: DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
  for td in soup.findAll("td"):"